### PR TITLE
feat: Improve CI to only run jobs when relevant files change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,25 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Check for relevant changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'apps/**'
+              - 'libs/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/**'
+
       - name: Checkout
         uses: actions/checkout@v4
+        if: steps.changes.outputs.src == 'true'
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
+        if: steps.changes.outputs.src == 'true'
         with:
           version: 9
           run_install: false
@@ -29,25 +43,45 @@ jobs:
 
       - name: Install Node.js
         uses: actions/setup-node@v4
+        if: steps.changes.outputs.src == 'true'
         with:
           node-version: 18.17.1
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.changes.outputs.src == 'true'
         run: pnpm run ci
 
       - name: Lint all projects
+        if: steps.changes.outputs.src == 'true'
         run: npm run lint
 
   build:
     runs-on: ubuntu-latest
+    # The existing if condition for the job can remain,
+    # as it controls whether the job runs at all based on event type or branch.
+    # The path filter will then control whether the steps within the job run.
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     steps:
+      - name: Check for relevant changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'apps/**'
+              - 'libs/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/**'
+
       - name: Checkout
         uses: actions/checkout@v4
+        if: steps.changes.outputs.src == 'true'
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
+        if: steps.changes.outputs.src == 'true'
         with:
           version: 9
           run_install: false
@@ -55,25 +89,43 @@ jobs:
 
       - name: Install Node.js
         uses: actions/setup-node@v4
+        if: steps.changes.outputs.src == 'true'
         with:
           node-version: 18.17.1
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.changes.outputs.src == 'true'
         run: pnpm run ci
 
       - name: Build all projects
+        if: steps.changes.outputs.src == 'true'
         run: npm run build
 
   test:
     runs-on: ubuntu-latest
+    # The existing if condition for the job can remain.
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     steps:
+      - name: Check for relevant changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'apps/**'
+              - 'libs/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/**'
+
       - name: Checkout
         uses: actions/checkout@v4
+        if: steps.changes.outputs.src == 'true'
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
+        if: steps.changes.outputs.src == 'true'
         with:
           version: 9
           run_install: false
@@ -81,12 +133,15 @@ jobs:
 
       - name: Install Node.js
         uses: actions/setup-node@v4
+        if: steps.changes.outputs.src == 'true'
         with:
           node-version: 18.17.1
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.changes.outputs.src == 'true'
         run: pnpm run ci
 
       - name: Test all projects
+        if: steps.changes.outputs.src == 'true'
         run: pnpm run test


### PR DESCRIPTION
This change introduces path filtering to the CI workflow.

Previously, all CI jobs (lint, build, test) would run on every push and pull request to the main branch, even if the changes were to files that do not affect the application's code (e.g., README.md).

Now, using the `dorny/paths-filter` GitHub Action, each job will only run if changes are detected in:
- Source code files (`apps/**`, `libs/**`)
- Dependency management files (`package.json`, `pnpm-lock.yaml`)
- CI workflow configuration files (`.github/workflows/**`)

This optimization will help save CI resources and provide faster feedback loops when changes are limited to non-code files.